### PR TITLE
Fix premature game over when clearing lines

### DIFF
--- a/tetris.html
+++ b/tetris.html
@@ -703,9 +703,10 @@
             if (collide(arena, player)) {
                 player.pos.y--;
                 merge(arena, player);
-                playerReset();
-                arenaSweep();
-                updateScore();
+                arenaSweep(() => {
+                    playerReset();
+                    updateScore();
+                });
             }
             dropCounter = 0;
         }
@@ -723,9 +724,10 @@
             }
             player.pos.y--;
             merge(arena, player);
-            playerReset();
-            arenaSweep();
-            updateScore();
+            arenaSweep(() => {
+                playerReset();
+                updateScore();
+            });
             dropCounter = 0;
         }
         
@@ -763,7 +765,7 @@
             }
         }
         
-        function arenaSweep() {
+        function arenaSweep(callback = () => {}) {
             let rowCount = 0;
             let rowsToRemove = [];
             
@@ -794,7 +796,10 @@
                     dropInterval = 1000 / level;
                     
                     updateScore();
+                    callback();
                 });
+            } else {
+                callback();
             }
         }
         

--- a/tetris_standalone.html
+++ b/tetris_standalone.html
@@ -949,14 +949,13 @@
                     // Объединяем фигуру с ареной
                     merge(arena, player);
                     
-                    // Создаем новую фигуру и проверяем на конец игры
-                    const gameEnded = playerReset();
-                    
-                    // Если игра не окончена, проверяем на заполненные линии
-                    if (!gameEnded) {
-                        arenaSweep();
-                        updateScore();
-                    }
+                    // После очистки заполненных линий создаем новую фигуру
+                    arenaSweep(() => {
+                        const ended = playerReset();
+                        if (!ended) {
+                            updateScore();
+                        }
+                    });
                 }
                 
                 // Сбрасываем счетчик падения
@@ -1009,15 +1008,13 @@
                 // Объединяем фигуру с ареной
                 merge(arena, player);
                 
-                // Создаем новую фигуру и проверяем на конец игры
-                const gameEnded = playerReset();
-                
-                // Если игра не окончена, проверяем на заполненные линии
-                if (!gameEnded) {
-                    arenaSweep();
-                    updateScore();
-                }
-                
+                arenaSweep(() => {
+                    const ended = playerReset();
+                    if (!ended) {
+                        updateScore();
+                    }
+                });
+
                 // Сбрасываем счетчик падения
                 dropCounter = 0;
                 
@@ -1138,7 +1135,7 @@
             }
         }
         
-        function arenaSweep() {
+        function arenaSweep(callback = () => {}) {
             let rowCount = 0;
             let rowsToRemove = [];
             
@@ -1174,10 +1171,13 @@
                         dropInterval = 1000 / level;
                         
                         updateScore();
+                        callback();
                     } catch (e) {
                         console.error("Ошибка при удалении строк:", e);
                     }
                 });
+            } else {
+                callback();
             }
         }
         


### PR DESCRIPTION
## Summary
- ensure next piece spawns after lines are cleared
- keep score updating in callback

## Testing
- `curl -s http://localhost:8080/tetris.html | head -n 10`

------
https://chatgpt.com/codex/tasks/task_e_688a03b8d8188330bc39b70b69f56079